### PR TITLE
Add unit tests

### DIFF
--- a/tests/test_game_history.py
+++ b/tests/test_game_history.py
@@ -1,0 +1,20 @@
+import numpy as np
+from self_play import GameHistory, MinMaxStats
+
+def test_get_stacked_observations_basic():
+    gh = GameHistory()
+    gh.observation_history = [np.array([[0.]]), np.array([[1.]]), np.array([[2.]])]
+    gh.action_history = [0, 1, 0]
+    stacked = gh.get_stacked_observations(2, 1, 2)
+    assert stacked.shape == (3, 1)
+    assert stacked[0, 0] == 2.0
+    assert stacked[1, 0] == 1.0
+    assert stacked[2, 0] == 0.0
+
+def test_min_max_stats_normalization():
+    stats = MinMaxStats()
+    stats.update(1.0)
+    stats.update(3.0)
+    assert stats.minimum == 1.0
+    assert stats.maximum == 3.0
+    assert stats.normalize(3.0) == 1.0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,15 @@
+import torch
+from models import dict_to_cpu
+
+def test_dict_to_cpu_tensor_moved_to_cpu():
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    data = {
+        'a': torch.tensor([1.0], device=device),
+        'b': {
+            'c': torch.tensor([2.0], device=device)
+        }
+    }
+    result = dict_to_cpu(data)
+    assert result['a'].device.type == 'cpu'
+    assert result['b']['c'].device.type == 'cpu'
+

--- a/tests/test_replay_buffer.py
+++ b/tests/test_replay_buffer.py
@@ -1,0 +1,50 @@
+import pytest
+import numpy as np
+from types import SimpleNamespace
+import replay_buffer
+from self_play import GameHistory
+
+ReplayBufferClass = replay_buffer.ReplayBuffer.__ray_metadata__.modified_class
+
+class DummyConfig(SimpleNamespace):
+    pass
+
+def create_dummy_config():
+    return DummyConfig(
+        seed=0,
+        PER=False,
+        PER_alpha=0.5,
+        replay_buffer_size=10,
+        batch_size=1,
+        stacked_observations=0,
+        action_space=[0, 1],
+        td_steps=2,
+        discount=0.9,
+        num_unroll_steps=2,
+    )
+
+def create_game_history():
+    gh = GameHistory()
+    gh.root_values = [1.0, 2.0, 3.0]
+    gh.reward_history = [0.0, 1.0, 2.0, 3.0]
+    gh.to_play_history = [0, 0, 0, 0]
+    gh.child_visits = [[0.5, 0.5], [0.6, 0.4], [0.7, 0.3]]
+    gh.action_history = [0, 1, 0, 1]
+    return gh
+
+def test_compute_target_value():
+    config = create_dummy_config()
+    rb = ReplayBufferClass({'num_played_games':0, 'num_played_steps':0}, {}, config)
+    gh = create_game_history()
+    value = rb.compute_target_value(gh, 1)
+    assert value == pytest.approx(4.7, rel=1e-5)
+
+def test_make_target():
+    config = create_dummy_config()
+    rb = ReplayBufferClass({'num_played_games':0, 'num_played_steps':0}, {}, config)
+    gh = create_game_history()
+    values, rewards, policies, actions = rb.make_target(gh, 1)
+    assert len(values) == config.num_unroll_steps + 1
+    assert rewards == [1.0, 2.0, 3.0]
+    assert actions == [1, 0, 1]
+


### PR DESCRIPTION
## Summary
- add unit tests for `dict_to_cpu`
- test `GameHistory` stacking logic and `MinMaxStats`
- test replay buffer target computations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68897ab2b61483338d1e6158171ea506